### PR TITLE
feat: implement console, network, and browser capture modules

### DIFF
--- a/src/capture/browser.test.ts
+++ b/src/capture/browser.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { collectBrowserInfo } from './browser';
+
+describe('collectBrowserInfo', () => {
+  beforeEach(() => {
+    // jsdom provides basic navigator/window/screen globals
+    // We mock specific values for deterministic tests
+    Object.defineProperty(window, 'innerWidth', { value: 1024, writable: true });
+    Object.defineProperty(window, 'innerHeight', { value: 768, writable: true });
+    Object.defineProperty(window, 'devicePixelRatio', { value: 2, writable: true });
+  });
+
+  it('returns all required fields', () => {
+    const info = collectBrowserInfo();
+
+    expect(info).toHaveProperty('userAgent');
+    expect(info).toHaveProperty('browser');
+    expect(info).toHaveProperty('os');
+    expect(info).toHaveProperty('language');
+    expect(info).toHaveProperty('platform');
+    expect(info).toHaveProperty('timezone');
+    expect(info).toHaveProperty('online');
+    expect(info).toHaveProperty('screenWidth');
+    expect(info).toHaveProperty('screenHeight');
+    expect(info).toHaveProperty('viewportWidth');
+    expect(info).toHaveProperty('viewportHeight');
+    expect(info).toHaveProperty('devicePixelRatio');
+    expect(info).toHaveProperty('url');
+    expect(info).toHaveProperty('referrer');
+  });
+
+  it('returns correct types for all fields', () => {
+    const info = collectBrowserInfo();
+
+    expect(info.userAgent).toBeTypeOf('string');
+    expect(info.browser).toBeTypeOf('string');
+    expect(info.os).toBeTypeOf('string');
+    expect(info.language).toBeTypeOf('string');
+    expect(info.platform).toBeTypeOf('string');
+    expect(info.timezone).toBeTypeOf('string');
+    expect(info.online).toBeTypeOf('boolean');
+    expect(info.screenWidth).toBeTypeOf('number');
+    expect(info.screenHeight).toBeTypeOf('number');
+    expect(info.viewportWidth).toBeTypeOf('number');
+    expect(info.viewportHeight).toBeTypeOf('number');
+    expect(info.devicePixelRatio).toBeTypeOf('number');
+    expect(info.url).toBeTypeOf('string');
+    expect(info.referrer).toBeTypeOf('string');
+  });
+
+  it('handles missing optional fields (memory, connection) gracefully', () => {
+    // jsdom does not provide performance.memory or navigator.connection
+    const info = collectBrowserInfo();
+
+    expect(info.memory).toBeUndefined();
+    expect(info.connection).toBeUndefined();
+  });
+
+  it('includes memory info when available', () => {
+    const mockMemory = {
+      jsHeapSizeLimit: 2000000000,
+      totalJSHeapSize: 50000000,
+      usedJSHeapSize: 30000000,
+    };
+
+    Object.defineProperty(performance, 'memory', {
+      value: mockMemory,
+      configurable: true,
+    });
+
+    const info = collectBrowserInfo();
+    expect(info.memory).toEqual(mockMemory);
+
+    // Clean up
+    Object.defineProperty(performance, 'memory', {
+      value: undefined,
+      configurable: true,
+    });
+  });
+
+  it('includes connection info when available', () => {
+    const mockConnection = {
+      effectiveType: '4g',
+      downlink: 10,
+      rtt: 50,
+    };
+
+    Object.defineProperty(navigator, 'connection', {
+      value: mockConnection,
+      configurable: true,
+    });
+
+    const info = collectBrowserInfo();
+    expect(info.connection).toEqual(mockConnection);
+
+    // Clean up
+    Object.defineProperty(navigator, 'connection', {
+      value: undefined,
+      configurable: true,
+    });
+  });
+
+  describe('UA parsing', () => {
+    it('parses Chrome user agent', () => {
+      const chromeUA =
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';
+      vi.spyOn(navigator, 'userAgent', 'get').mockReturnValue(chromeUA);
+
+      const info = collectBrowserInfo();
+      expect(info.browser).toContain('Chrome');
+      expect(info.browser).toContain('120');
+      expect(info.os).toContain('Windows');
+
+      vi.restoreAllMocks();
+    });
+
+    it('parses Firefox user agent', () => {
+      const firefoxUA =
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:121.0) Gecko/20100101 Firefox/121.0';
+      vi.spyOn(navigator, 'userAgent', 'get').mockReturnValue(firefoxUA);
+
+      const info = collectBrowserInfo();
+      expect(info.browser).toContain('Firefox');
+      expect(info.browser).toContain('121');
+      expect(info.os).toContain('macOS');
+
+      vi.restoreAllMocks();
+    });
+
+    it('parses Edge user agent', () => {
+      const edgeUA =
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36 Edg/120.0.0.0';
+      vi.spyOn(navigator, 'userAgent', 'get').mockReturnValue(edgeUA);
+
+      const info = collectBrowserInfo();
+      expect(info.browser).toContain('Edge');
+
+      vi.restoreAllMocks();
+    });
+
+    it('parses Safari user agent', () => {
+      const safariUA =
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.2 Safari/605.1.15';
+      vi.spyOn(navigator, 'userAgent', 'get').mockReturnValue(safariUA);
+
+      const info = collectBrowserInfo();
+      expect(info.browser).toContain('Safari');
+      expect(info.browser).toContain('17.2');
+
+      vi.restoreAllMocks();
+    });
+
+    it('returns Unknown for unrecognized UA strings', () => {
+      vi.spyOn(navigator, 'userAgent', 'get').mockReturnValue('SomeWeirdBot/1.0');
+
+      const info = collectBrowserInfo();
+      expect(info.browser).toBe('Unknown');
+      expect(info.os).toBe('Unknown');
+
+      vi.restoreAllMocks();
+    });
+
+    it('parses Android user agent', () => {
+      const androidUA =
+        'Mozilla/5.0 (Linux; Android 13; Pixel 7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36';
+      vi.spyOn(navigator, 'userAgent', 'get').mockReturnValue(androidUA);
+
+      const info = collectBrowserInfo();
+      expect(info.os).toContain('Android');
+      expect(info.os).toContain('13');
+
+      vi.restoreAllMocks();
+    });
+
+    it('parses iOS user agent', () => {
+      const iosUA =
+        'Mozilla/5.0 (iPhone; CPU iPhone OS 17_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.2 Mobile/15E148 Safari/604.1';
+      vi.spyOn(navigator, 'userAgent', 'get').mockReturnValue(iosUA);
+
+      const info = collectBrowserInfo();
+      expect(info.os).toContain('iOS');
+      expect(info.os).toContain('17.2');
+
+      vi.restoreAllMocks();
+    });
+  });
+
+  it('reads viewport dimensions from window', () => {
+    Object.defineProperty(window, 'innerWidth', { value: 1440, writable: true });
+    Object.defineProperty(window, 'innerHeight', { value: 900, writable: true });
+
+    const info = collectBrowserInfo();
+    expect(info.viewportWidth).toBe(1440);
+    expect(info.viewportHeight).toBe(900);
+  });
+
+  it('reads timezone from Intl API', () => {
+    const info = collectBrowserInfo();
+    // jsdom should provide a timezone string
+    expect(info.timezone).toBeTypeOf('string');
+    expect(info.timezone.length).toBeGreaterThan(0);
+  });
+});

--- a/src/capture/browser.ts
+++ b/src/capture/browser.ts
@@ -1,2 +1,90 @@
-// Browser/device info collector — placeholder
-export {};
+import type { BrowserInfo } from '../types';
+
+function parseBrowser(ua: string): string {
+  // Order matters — check more specific browsers first
+  const browsers: [RegExp, string][] = [
+    [/Edg(?:e|A|iOS)?\/(\S+)/, 'Edge'],
+    [/OPR\/(\S+)/, 'Opera'],
+    [/SamsungBrowser\/(\S+)/, 'Samsung Internet'],
+    [/(?:Chrome|CriOS)\/(\S+)/, 'Chrome'],
+    [/(?:Firefox|FxiOS)\/(\S+)/, 'Firefox'],
+    [/Version\/(\S+).*Safari/, 'Safari'],
+  ];
+
+  for (const [pattern, name] of browsers) {
+    const match = ua.match(pattern);
+    if (match) {
+      return `${name} ${match[1]}`;
+    }
+  }
+
+  return 'Unknown';
+}
+
+function parseOS(ua: string): string {
+  const osPatterns: [RegExp, (m: RegExpMatchArray) => string][] = [
+    [/Windows NT ([\d.]+)/, (m) => `Windows ${m[1]}`],
+    [/Mac OS X ([\d._]+)/, (m) => `macOS ${m[1].replace(/_/g, '.')}`],
+    [/Android ([\d.]+)/, (m) => `Android ${m[1]}`],
+    [/iPhone OS ([\d_]+)/, (m) => `iOS ${m[1].replace(/_/g, '.')}`],
+    [/iPad.*OS ([\d_]+)/, (m) => `iPadOS ${m[1].replace(/_/g, '.')}`],
+    [/Linux/, () => 'Linux'],
+    [/CrOS/, () => 'Chrome OS'],
+  ];
+
+  for (const [pattern, formatter] of osPatterns) {
+    const match = ua.match(pattern);
+    if (match) {
+      return formatter(match);
+    }
+  }
+
+  return 'Unknown';
+}
+
+export function collectBrowserInfo(): BrowserInfo {
+  const ua = navigator.userAgent;
+
+  const info: BrowserInfo = {
+    userAgent: ua,
+    browser: parseBrowser(ua),
+    os: parseOS(ua),
+    language: navigator.language,
+    platform: navigator.platform,
+    timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+    online: navigator.onLine,
+    screenWidth: screen.width,
+    screenHeight: screen.height,
+    viewportWidth: window.innerWidth,
+    viewportHeight: window.innerHeight,
+    devicePixelRatio: window.devicePixelRatio,
+    url: window.location.href,
+    referrer: document.referrer,
+  };
+
+  // Chrome-only: performance.memory
+  const perf = performance as unknown as {
+    memory?: { jsHeapSizeLimit: number; totalJSHeapSize: number; usedJSHeapSize: number };
+  };
+  if (perf.memory) {
+    info.memory = {
+      jsHeapSizeLimit: perf.memory.jsHeapSizeLimit,
+      totalJSHeapSize: perf.memory.totalJSHeapSize,
+      usedJSHeapSize: perf.memory.usedJSHeapSize,
+    };
+  }
+
+  // Network Information API (optional)
+  const nav = navigator as unknown as {
+    connection?: { effectiveType: string; downlink: number; rtt: number };
+  };
+  if (nav.connection) {
+    info.connection = {
+      effectiveType: nav.connection.effectiveType,
+      downlink: nav.connection.downlink,
+      rtt: nav.connection.rtt,
+    };
+  }
+
+  return info;
+}

--- a/src/capture/console.test.ts
+++ b/src/capture/console.test.ts
@@ -1,0 +1,205 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createConsoleCapture } from './console';
+import { Sanitizer } from '../core/sanitizer';
+import type { ConsoleLevel } from '../types';
+
+describe('createConsoleCapture', () => {
+  let sanitizer: Sanitizer;
+  const originals: Record<string, unknown> = {};
+
+  beforeEach(() => {
+    sanitizer = new Sanitizer();
+    // Save originals before each test
+    for (const level of ['log', 'info', 'warn', 'error', 'debug'] as const) {
+      originals[level] = console[level];
+    }
+  });
+
+  afterEach(() => {
+    // Restore originals after each test (safety net)
+    for (const level of ['log', 'info', 'warn', 'error', 'debug'] as const) {
+      (console as Record<string, unknown>)[level] = originals[level];
+    }
+  });
+
+  it('intercepts all 5 log levels', () => {
+    const capture = createConsoleCapture(sanitizer, 50);
+    capture.start();
+
+    console.log('log message');
+    console.info('info message');
+    console.warn('warn message');
+    console.error('error message');
+    console.debug('debug message');
+
+    const entries = capture.getEntries();
+    expect(entries).toHaveLength(5);
+
+    const levels = entries.map((e) => e.level);
+    expect(levels).toEqual(['log', 'info', 'warn', 'error', 'debug']);
+
+    capture.stop();
+  });
+
+  it('calls original console methods', () => {
+    const spies: Record<string, ReturnType<typeof vi.fn>> = {};
+    for (const level of ['log', 'info', 'warn', 'error', 'debug'] as const) {
+      spies[level] = vi.fn();
+      (console as Record<string, unknown>)[level] = spies[level];
+    }
+
+    const capture = createConsoleCapture(sanitizer, 50);
+    capture.start();
+
+    console.log('test');
+    console.info('test');
+    console.warn('test');
+    console.error('test');
+    console.debug('test');
+
+    for (const level of ['log', 'info', 'warn', 'error', 'debug'] as const) {
+      expect(spies[level]).toHaveBeenCalledWith('test');
+    }
+
+    capture.stop();
+  });
+
+  it('stores entries with correct shape', () => {
+    const capture = createConsoleCapture(sanitizer, 50);
+    capture.start();
+
+    const before = Date.now();
+    console.log('hello', 'world', 42);
+    const after = Date.now();
+
+    const entries = capture.getEntries();
+    expect(entries).toHaveLength(1);
+
+    const entry = entries[0];
+    expect(entry.level).toBe('log');
+    expect(entry.message).toBe('hello');
+    expect(entry.args).toEqual(['world', '42']);
+    expect(entry.timestamp).toBeGreaterThanOrEqual(before);
+    expect(entry.timestamp).toBeLessThanOrEqual(after);
+
+    capture.stop();
+  });
+
+  it('sanitizes message and args', () => {
+    const capture = createConsoleCapture(sanitizer, 50);
+    capture.start();
+
+    console.log('email: user@example.com', 'token: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.sig');
+
+    const entries = capture.getEntries();
+    expect(entries[0].message).toContain('[REDACTED:email]');
+    expect(entries[0].args[0]).toContain('[REDACTED:jwt]');
+
+    capture.stop();
+  });
+
+  it('stop() restores original console methods', () => {
+    const originalLog = console.log;
+    const capture = createConsoleCapture(sanitizer, 50);
+
+    capture.start();
+    expect(console.log).not.toBe(originalLog);
+
+    capture.stop();
+    expect(console.log).toBe(originalLog);
+  });
+
+  it('respects buffer capacity limit', () => {
+    const capture = createConsoleCapture(sanitizer, 3);
+    capture.start();
+
+    console.log('one');
+    console.log('two');
+    console.log('three');
+    console.log('four');
+
+    const entries = capture.getEntries();
+    expect(entries).toHaveLength(3);
+    expect(entries[0].message).toBe('two');
+    expect(entries[2].message).toBe('four');
+
+    capture.stop();
+  });
+
+  it('freeze() returns a copy that does not change', () => {
+    const capture = createConsoleCapture(sanitizer, 50);
+    capture.start();
+
+    console.log('before freeze');
+    const frozen = capture.freeze();
+
+    console.log('after freeze');
+    expect(frozen).toHaveLength(1);
+    expect(frozen[0].message).toBe('before freeze');
+
+    expect(capture.getEntries()).toHaveLength(2);
+
+    capture.stop();
+  });
+
+  it('clear() empties the buffer', () => {
+    const capture = createConsoleCapture(sanitizer, 50);
+    capture.start();
+
+    console.log('test');
+    expect(capture.getEntries()).toHaveLength(1);
+
+    capture.clear();
+    expect(capture.getEntries()).toHaveLength(0);
+
+    capture.stop();
+  });
+
+  it('captures stack trace for console.error', () => {
+    const capture = createConsoleCapture(sanitizer, 50);
+    capture.start();
+
+    console.error('something failed');
+
+    const entries = capture.getEntries();
+    const errorEntry = entries[0];
+    expect(errorEntry.level).toBe('error');
+    // The last arg should be a stack trace string
+    const lastArg = errorEntry.args[errorEntry.args.length - 1];
+    expect(lastArg).toContain('Error');
+
+    capture.stop();
+  });
+
+  it('handles non-string arguments (objects, numbers)', () => {
+    const capture = createConsoleCapture(sanitizer, 50);
+    capture.start();
+
+    console.log({ key: 'value' }, 123, true);
+
+    const entries = capture.getEntries();
+    expect(entries[0].message).toBe('{"key":"value"}');
+    expect(entries[0].args).toEqual(['123', 'true']);
+
+    capture.stop();
+  });
+
+  it('does not capture entries when not started', () => {
+    const capture = createConsoleCapture(sanitizer, 50);
+
+    console.log('not captured');
+
+    expect(capture.getEntries()).toHaveLength(0);
+  });
+
+  it('does not capture entries after stop', () => {
+    const capture = createConsoleCapture(sanitizer, 50);
+    capture.start();
+    console.log('captured');
+    capture.stop();
+    console.log('not captured');
+
+    expect(capture.getEntries()).toHaveLength(1);
+    expect(capture.getEntries()[0].message).toBe('captured');
+  });
+});

--- a/src/capture/console.ts
+++ b/src/capture/console.ts
@@ -1,2 +1,92 @@
-// Console log interceptor — placeholder
-export {};
+import { RingBuffer } from '../core/ring-buffer';
+import { Sanitizer } from '../core/sanitizer';
+import type { ConsoleEntry, ConsoleLevel } from '../types';
+
+export interface ConsoleCapture {
+  start(): void;
+  stop(): void;
+  getEntries(): ConsoleEntry[];
+  freeze(): ConsoleEntry[];
+  clear(): void;
+}
+
+const LEVELS: ConsoleLevel[] = ['log', 'info', 'warn', 'error', 'debug'];
+
+function stringify(value: unknown): string {
+  if (typeof value === 'string') return value;
+  if (value instanceof Error) return value.message;
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+export function createConsoleCapture(
+  sanitizer: Sanitizer,
+  bufferSize: number,
+): ConsoleCapture {
+  const buffer = new RingBuffer<ConsoleEntry>(bufferSize);
+  const originals = new Map<ConsoleLevel, (...args: unknown[]) => void>();
+  let active = false;
+
+  function start(): void {
+    if (active) return;
+    active = true;
+
+    for (const level of LEVELS) {
+      originals.set(level, console[level] as (...args: unknown[]) => void);
+
+      (console as unknown as Record<string, unknown>)[level] = (...args: unknown[]) => {
+        const original = originals.get(level)!;
+        original.apply(console, args);
+
+        const message = sanitizer.sanitizeString(stringify(args[0] ?? ''));
+        const rest = args.slice(1).map((a) => sanitizer.sanitizeString(stringify(a)));
+
+        const entry: ConsoleEntry = {
+          level,
+          message,
+          args: rest,
+          timestamp: Date.now(),
+        };
+
+        if (level === 'error') {
+          const stack = new Error().stack;
+          if (stack) {
+            entry.args = [...rest, sanitizer.sanitizeString(stack)];
+          }
+        }
+
+        buffer.push(entry);
+      };
+    }
+  }
+
+  function stop(): void {
+    if (!active) return;
+    active = false;
+
+    for (const level of LEVELS) {
+      const original = originals.get(level);
+      if (original) {
+        (console as unknown as Record<string, unknown>)[level] = original;
+      }
+    }
+    originals.clear();
+  }
+
+  function getEntries(): ConsoleEntry[] {
+    return buffer.getAll();
+  }
+
+  function freeze(): ConsoleEntry[] {
+    return buffer.freeze();
+  }
+
+  function clear(): void {
+    buffer.clear();
+  }
+
+  return { start, stop, getEntries, freeze, clear };
+}

--- a/src/capture/network.test.ts
+++ b/src/capture/network.test.ts
@@ -1,0 +1,470 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createNetworkCapture } from './network';
+import { Sanitizer } from '../core/sanitizer';
+
+describe('createNetworkCapture', () => {
+  let sanitizer: Sanitizer;
+  let originalFetch: typeof globalThis.fetch;
+  let originalXHROpen: typeof XMLHttpRequest.prototype.open;
+  let originalXHRSend: typeof XMLHttpRequest.prototype.send;
+  let originalXHRSetRequestHeader: typeof XMLHttpRequest.prototype.setRequestHeader;
+
+  beforeEach(() => {
+    sanitizer = new Sanitizer();
+    originalFetch = globalThis.fetch;
+    originalXHROpen = XMLHttpRequest.prototype.open;
+    originalXHRSend = XMLHttpRequest.prototype.send;
+    originalXHRSetRequestHeader = XMLHttpRequest.prototype.setRequestHeader;
+  });
+
+  afterEach(() => {
+    // Safety net: restore globals
+    globalThis.fetch = originalFetch;
+    XMLHttpRequest.prototype.open = originalXHROpen;
+    XMLHttpRequest.prototype.send = originalXHRSend;
+    XMLHttpRequest.prototype.setRequestHeader = originalXHRSetRequestHeader;
+  });
+
+  describe('fetch interception', () => {
+    it('captures fetch requests with correct metadata', async () => {
+      const mockFetch = vi.fn().mockResolvedValue(
+        new Response('{"ok":true}', {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+      );
+      globalThis.fetch = mockFetch;
+
+      const capture = createNetworkCapture(sanitizer, 50);
+      capture.start();
+
+      await fetch('https://api.example.com/data', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: '{"name":"test"}',
+      });
+
+      const entries = capture.getEntries();
+      expect(entries).toHaveLength(1);
+
+      const entry = entries[0];
+      expect(entry.method).toBe('POST');
+      expect(entry.url).toContain('api.example.com/data');
+      expect(entry.status).toBe(200);
+      expect(entry.requestBody).toBe('{"name":"test"}');
+      expect(entry.responseBody).toBe('{"ok":true}');
+      expect(entry.duration).toBeTypeOf('number');
+      expect(entry.duration).toBeGreaterThanOrEqual(0);
+      expect(entry.timestamp).toBeTypeOf('number');
+
+      capture.stop();
+    });
+
+    it('sanitizes URLs', async () => {
+      const mockFetch = vi.fn().mockResolvedValue(
+        new Response('ok', { status: 200, headers: { 'content-type': 'text/plain' } }),
+      );
+      globalThis.fetch = mockFetch;
+
+      const capture = createNetworkCapture(sanitizer, 50);
+      capture.start();
+
+      await fetch('https://api.example.com/auth?token=secret123&page=1');
+
+      const entries = capture.getEntries();
+      expect(entries[0].url).toContain('token=%5BREDACTED%5D');
+      expect(entries[0].url).toContain('page=1');
+
+      capture.stop();
+    });
+
+    it('sanitizes request and response headers', async () => {
+      const mockFetch = vi.fn().mockResolvedValue(
+        new Response('ok', {
+          status: 200,
+          headers: { 'content-type': 'text/plain', 'x-custom': 'value' },
+        }),
+      );
+      globalThis.fetch = mockFetch;
+
+      const capture = createNetworkCapture(sanitizer, 50);
+      capture.start();
+
+      await fetch('https://api.example.com/data', {
+        headers: {
+          Authorization: 'Bearer secret',
+          'Content-Type': 'application/json',
+        },
+        body: '{}',
+      });
+
+      const entries = capture.getEntries();
+      // Authorization should be stripped
+      expect(entries[0].requestHeaders).not.toHaveProperty('Authorization');
+      expect(entries[0].requestHeaders['Content-Type']).toBe('application/json');
+
+      capture.stop();
+    });
+
+    it('sanitizes request and response bodies', async () => {
+      const mockFetch = vi.fn().mockResolvedValue(
+        new Response('{"email":"user@example.com"}', {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+      );
+      globalThis.fetch = mockFetch;
+
+      const capture = createNetworkCapture(sanitizer, 50);
+      capture.start();
+
+      await fetch('https://api.example.com/data', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: '{"email":"admin@test.com"}',
+      });
+
+      const entries = capture.getEntries();
+      expect(entries[0].requestBody).toContain('[REDACTED:email]');
+      expect(entries[0].responseBody).toContain('[REDACTED:email]');
+
+      capture.stop();
+    });
+
+    it('logs binary responses as [binary, ...]', async () => {
+      const mockFetch = vi.fn().mockResolvedValue(
+        new Response(new Uint8Array(100), {
+          status: 200,
+          headers: { 'content-type': 'image/png', 'content-length': '100' },
+        }),
+      );
+      globalThis.fetch = mockFetch;
+
+      const capture = createNetworkCapture(sanitizer, 50);
+      capture.start();
+
+      await fetch('https://api.example.com/image.png');
+
+      const entries = capture.getEntries();
+      expect(entries[0].responseBody).toBe('[binary, 100 bytes]');
+
+      capture.stop();
+    });
+
+    it('truncates bodies exceeding maxBodySize', async () => {
+      const largeBody = 'x'.repeat(200);
+      const mockFetch = vi.fn().mockResolvedValue(
+        new Response(largeBody, {
+          status: 200,
+          headers: { 'content-type': 'text/plain' },
+        }),
+      );
+      globalThis.fetch = mockFetch;
+
+      const capture = createNetworkCapture(sanitizer, 50, 100);
+      capture.start();
+
+      await fetch('https://api.example.com/data', {
+        method: 'POST',
+        headers: { 'Content-Type': 'text/plain' },
+        body: largeBody,
+      });
+
+      const entries = capture.getEntries();
+      expect(entries[0].requestBody).toContain('[truncated, 200 bytes total]');
+      expect(entries[0].responseBody).toContain('[truncated, 200 bytes total]');
+
+      capture.stop();
+    });
+
+    it('stop() restores original fetch', () => {
+      const mockFetch = vi.fn();
+      globalThis.fetch = mockFetch;
+
+      const capture = createNetworkCapture(sanitizer, 50);
+      capture.start();
+
+      expect(globalThis.fetch).not.toBe(mockFetch);
+
+      capture.stop();
+      expect(globalThis.fetch).toBe(mockFetch);
+    });
+
+    it('records duration', async () => {
+      const mockFetch = vi.fn().mockResolvedValue(
+        new Response('ok', { status: 200, headers: { 'content-type': 'text/plain' } }),
+      );
+      globalThis.fetch = mockFetch;
+
+      const capture = createNetworkCapture(sanitizer, 50);
+      capture.start();
+
+      await fetch('https://api.example.com/data');
+
+      const entries = capture.getEntries();
+      expect(entries[0].duration).toBeTypeOf('number');
+      expect(entries[0].duration).toBeGreaterThanOrEqual(0);
+
+      capture.stop();
+    });
+
+    it('excludes SDK own requests', async () => {
+      const mockFetch = vi.fn().mockResolvedValue(
+        new Response('ok', { status: 200, headers: { 'content-type': 'text/plain' } }),
+      );
+      globalThis.fetch = mockFetch;
+
+      const capture = createNetworkCapture(sanitizer, 50) as ReturnType<typeof createNetworkCapture> & {
+        setExcludedEndpoint: (endpoint: string) => void;
+      };
+      capture.setExcludedEndpoint('https://api.support.com/reports');
+      capture.start();
+
+      // This request should be excluded
+      await fetch('https://api.support.com/reports', { method: 'POST' });
+      // This request should be captured
+      await fetch('https://api.example.com/data');
+
+      const entries = capture.getEntries();
+      expect(entries).toHaveLength(1);
+      expect(entries[0].url).toContain('api.example.com');
+
+      capture.stop();
+    });
+
+    it('captures failed fetch requests', async () => {
+      const error = new Error('Network error');
+      const mockFetch = vi.fn().mockRejectedValue(error);
+      globalThis.fetch = mockFetch;
+
+      const capture = createNetworkCapture(sanitizer, 50);
+      capture.start();
+
+      await expect(fetch('https://api.example.com/fail')).rejects.toThrow('Network error');
+
+      const entries = capture.getEntries();
+      expect(entries).toHaveLength(1);
+      expect(entries[0].status).toBeNull();
+
+      capture.stop();
+    });
+
+    it('handles fetch with URL object', async () => {
+      const mockFetch = vi.fn().mockResolvedValue(
+        new Response('ok', { status: 200, headers: { 'content-type': 'text/plain' } }),
+      );
+      globalThis.fetch = mockFetch;
+
+      const capture = createNetworkCapture(sanitizer, 50);
+      capture.start();
+
+      await fetch(new URL('https://api.example.com/data'));
+
+      const entries = capture.getEntries();
+      expect(entries).toHaveLength(1);
+      expect(entries[0].url).toContain('api.example.com/data');
+
+      capture.stop();
+    });
+
+    it('defaults method to GET', async () => {
+      const mockFetch = vi.fn().mockResolvedValue(
+        new Response('ok', { status: 200, headers: { 'content-type': 'text/plain' } }),
+      );
+      globalThis.fetch = mockFetch;
+
+      const capture = createNetworkCapture(sanitizer, 50);
+      capture.start();
+
+      await fetch('https://api.example.com/data');
+
+      const entries = capture.getEntries();
+      expect(entries[0].method).toBe('GET');
+
+      capture.stop();
+    });
+  });
+
+  describe('XHR interception', () => {
+    // jsdom's XHR tries to make real network requests which causes timeouts.
+    // We replace the global XMLHttpRequest with a fake before capture.start().
+    let xhrInstances: FakeXHR[];
+    let RealXHR: typeof XMLHttpRequest;
+
+    class FakeXHR extends EventTarget {
+      readyState = 0;
+      status = 0;
+      responseText = '';
+      responseType = '';
+      response: string | null = '';
+
+      open(_method: string, _url: string | URL, ..._rest: unknown[]) {
+        this.readyState = 1;
+      }
+
+      setRequestHeader(_name: string, _value: string) {
+        // no-op base
+      }
+
+      send(_body?: unknown) {
+        xhrInstances.push(this);
+      }
+
+      getAllResponseHeaders() {
+        return '';
+      }
+
+      abort() {}
+
+      /** Test helper: simulate a completed response */
+      _respond(status: number, headers: Record<string, string>, body: string) {
+        Object.defineProperty(this, 'getAllResponseHeaders', {
+          value: () =>
+            Object.entries(headers)
+              .map(([k, v]) => `${k}: ${v}`)
+              .join('\r\n'),
+        });
+        this.status = status;
+        this.responseText = body;
+        this.response = body;
+        this.readyState = 4;
+        this.dispatchEvent(new Event('loadend'));
+      }
+    }
+
+    beforeEach(() => {
+      xhrInstances = [];
+      RealXHR = globalThis.XMLHttpRequest;
+      // Install our fake as the global XMLHttpRequest
+      (globalThis as unknown as Record<string, unknown>).XMLHttpRequest = FakeXHR;
+    });
+
+    afterEach(() => {
+      // Restore real XMLHttpRequest
+      (globalThis as unknown as Record<string, unknown>).XMLHttpRequest = RealXHR;
+    });
+
+    it('captures XHR requests with correct metadata', () => {
+      const capture = createNetworkCapture(sanitizer, 50);
+      capture.start();
+
+      const xhr = new XMLHttpRequest();
+      xhr.open('GET', 'https://api.example.com/data');
+      xhr.send();
+
+      // Simulate server response
+      xhrInstances[0]._respond(200, { 'content-type': 'application/json' }, '{"ok":true}');
+
+      const entries = capture.getEntries();
+      expect(entries).toHaveLength(1);
+      expect(entries[0].method).toBe('GET');
+      expect(entries[0].url).toContain('api.example.com/data');
+      expect(entries[0].status).toBe(200);
+      expect(entries[0].responseBody).toBe('{"ok":true}');
+      expect(entries[0].duration).toBeTypeOf('number');
+      expect(entries[0].duration).toBeGreaterThanOrEqual(0);
+
+      capture.stop();
+    });
+
+    it('stop() restores original XHR prototype methods', () => {
+      const openBefore = XMLHttpRequest.prototype.open;
+      const sendBefore = XMLHttpRequest.prototype.send;
+
+      const capture = createNetworkCapture(sanitizer, 50);
+      capture.start();
+
+      expect(XMLHttpRequest.prototype.open).not.toBe(openBefore);
+      expect(XMLHttpRequest.prototype.send).not.toBe(sendBefore);
+
+      capture.stop();
+
+      expect(XMLHttpRequest.prototype.open).toBe(openBefore);
+      expect(XMLHttpRequest.prototype.send).toBe(sendBefore);
+    });
+
+    it('excludes SDK own XHR requests', () => {
+      const capture = createNetworkCapture(sanitizer, 50) as ReturnType<typeof createNetworkCapture> & {
+        setExcludedEndpoint: (endpoint: string) => void;
+      };
+      capture.setExcludedEndpoint('https://api.support.com/reports');
+      capture.start();
+
+      const xhr = new XMLHttpRequest();
+      xhr.open('POST', 'https://api.support.com/reports');
+      xhr.send();
+
+      // The excluded request's send calls the original (mock) send which pushes to xhrInstances,
+      // but no loadend listener is added by the capture module. Simulate response anyway.
+      if (xhrInstances.length > 0) {
+        xhrInstances[0]._respond(200, {}, 'ok');
+      }
+
+      const entries = capture.getEntries();
+      expect(entries).toHaveLength(0);
+
+      capture.stop();
+    });
+
+    it('captures XHR request headers and sanitizes them', () => {
+      const capture = createNetworkCapture(sanitizer, 50);
+      capture.start();
+
+      const xhr = new XMLHttpRequest();
+      xhr.open('POST', 'https://api.example.com/data');
+      xhr.setRequestHeader('Content-Type', 'application/json');
+      xhr.setRequestHeader('Authorization', 'Bearer secret');
+      xhr.send('{"test":true}');
+
+      xhrInstances[0]._respond(200, { 'content-type': 'application/json' }, '{"ok":true}');
+
+      const entries = capture.getEntries();
+      expect(entries).toHaveLength(1);
+      // Authorization should be stripped
+      expect(entries[0].requestHeaders).not.toHaveProperty('Authorization');
+      expect(entries[0].requestHeaders['Content-Type']).toBe('application/json');
+
+      capture.stop();
+    });
+  });
+
+  describe('buffer operations', () => {
+    it('freeze() returns a copy', async () => {
+      const mockFetch = vi.fn().mockResolvedValue(
+        new Response('ok', { status: 200, headers: { 'content-type': 'text/plain' } }),
+      );
+      globalThis.fetch = mockFetch;
+
+      const capture = createNetworkCapture(sanitizer, 50);
+      capture.start();
+
+      await fetch('https://api.example.com/first');
+      const frozen = capture.freeze();
+
+      await fetch('https://api.example.com/second');
+
+      expect(frozen).toHaveLength(1);
+      expect(capture.getEntries()).toHaveLength(2);
+
+      capture.stop();
+    });
+
+    it('clear() empties the buffer', async () => {
+      const mockFetch = vi.fn().mockResolvedValue(
+        new Response('ok', { status: 200, headers: { 'content-type': 'text/plain' } }),
+      );
+      globalThis.fetch = mockFetch;
+
+      const capture = createNetworkCapture(sanitizer, 50);
+      capture.start();
+
+      await fetch('https://api.example.com/data');
+      expect(capture.getEntries()).toHaveLength(1);
+
+      capture.clear();
+      expect(capture.getEntries()).toHaveLength(0);
+
+      capture.stop();
+    });
+  });
+});

--- a/src/capture/network.ts
+++ b/src/capture/network.ts
@@ -1,2 +1,359 @@
-// Fetch + XHR interceptor — placeholder
-export {};
+import { RingBuffer } from '../core/ring-buffer';
+import { Sanitizer } from '../core/sanitizer';
+import type { NetworkEntry } from '../types';
+
+export interface NetworkCapture {
+  start(): void;
+  stop(): void;
+  getEntries(): NetworkEntry[];
+  freeze(): NetworkEntry[];
+  clear(): void;
+}
+
+const DEFAULT_MAX_BODY_SIZE = 10_000;
+
+function isTextContentType(contentType: string | null | undefined): boolean {
+  if (!contentType) return false;
+  return contentType.includes('application/json') || contentType.includes('text/plain');
+}
+
+function headersToRecord(headers: Headers): Record<string, string> {
+  const record: Record<string, string> = {};
+  headers.forEach((value, key) => {
+    record[key] = value;
+  });
+  return record;
+}
+
+function extractBodyString(
+  body: BodyInit | null | undefined,
+  maxBodySize: number,
+): string | null {
+  if (body === null || body === undefined) return null;
+  if (typeof body === 'string') {
+    if (body.length > maxBodySize) {
+      return `[truncated, ${body.length} bytes total]`;
+    }
+    return body;
+  }
+  // For other types (Blob, ArrayBuffer, FormData, etc.), skip
+  return null;
+}
+
+export function createNetworkCapture(
+  sanitizer: Sanitizer,
+  bufferSize: number,
+  maxBodySize: number = DEFAULT_MAX_BODY_SIZE,
+): NetworkCapture {
+  const buffer = new RingBuffer<NetworkEntry>(bufferSize);
+  let active = false;
+
+  let originalFetch: typeof globalThis.fetch | null = null;
+  let originalXHROpen: typeof XMLHttpRequest.prototype.open | null = null;
+  let originalXHRSend: typeof XMLHttpRequest.prototype.send | null = null;
+  let originalXHRSetRequestHeader: typeof XMLHttpRequest.prototype.setRequestHeader | null = null;
+
+  // URL to exclude (the SDK's own endpoint)
+  let excludedEndpoint: string | null = null;
+
+  function setExcludedEndpoint(endpoint: string): void {
+    excludedEndpoint = endpoint;
+  }
+
+  function shouldExclude(url: string): boolean {
+    if (!excludedEndpoint) return false;
+    return url.startsWith(excludedEndpoint);
+  }
+
+  function startFetchInterception(): void {
+    originalFetch = globalThis.fetch;
+
+    globalThis.fetch = async function (
+      input: RequestInfo | URL,
+      init?: RequestInit,
+    ): Promise<Response> {
+      const method = (init?.method ?? 'GET').toUpperCase();
+      let url: string;
+
+      if (typeof input === 'string') {
+        url = input;
+      } else if (input instanceof URL) {
+        url = input.toString();
+      } else {
+        url = input.url;
+      }
+
+      if (shouldExclude(url)) {
+        return originalFetch!.call(globalThis, input, init);
+      }
+
+      const sanitizedUrl = sanitizer.sanitizeUrl(url);
+
+      // Extract request headers
+      let reqHeaders: Record<string, string> = {};
+      if (init?.headers) {
+        if (init.headers instanceof Headers) {
+          reqHeaders = headersToRecord(init.headers);
+        } else if (Array.isArray(init.headers)) {
+          for (const [key, value] of init.headers) {
+            reqHeaders[key] = value;
+          }
+        } else {
+          reqHeaders = { ...(init.headers as Record<string, string>) };
+        }
+      }
+      const sanitizedReqHeaders = sanitizer.sanitizeHeaders(reqHeaders);
+
+      // Extract request body
+      let requestBody: string | null = null;
+      const reqContentType = reqHeaders['content-type'] ?? reqHeaders['Content-Type'] ?? '';
+      if (isTextContentType(reqContentType)) {
+        requestBody = extractBodyString(init?.body, maxBodySize);
+        if (requestBody) {
+          requestBody = sanitizer.sanitizeString(requestBody);
+        }
+      }
+
+      const startTime = performance.now();
+
+      try {
+        const response = await originalFetch!.call(globalThis, input, init);
+        const duration = Math.round(performance.now() - startTime);
+
+        // Extract response headers
+        const resHeaders = headersToRecord(response.headers);
+        const sanitizedResHeaders = sanitizer.sanitizeHeaders(resHeaders);
+
+        // Extract response body
+        let responseBody: string | null = null;
+        const resContentType = response.headers.get('content-type');
+        if (isTextContentType(resContentType)) {
+          try {
+            const cloned = response.clone();
+            const text = await cloned.text();
+            if (text.length > maxBodySize) {
+              responseBody = `[truncated, ${text.length} bytes total]`;
+            } else {
+              responseBody = sanitizer.sanitizeString(text);
+            }
+          } catch {
+            responseBody = null;
+          }
+        } else if (resContentType) {
+          // Binary content — record size hint
+          const contentLength = response.headers.get('content-length');
+          if (contentLength) {
+            responseBody = `[binary, ${contentLength} bytes]`;
+          } else {
+            responseBody = '[binary]';
+          }
+        }
+
+        const entry: NetworkEntry = {
+          method,
+          url: sanitizedUrl,
+          status: response.status,
+          requestHeaders: sanitizedReqHeaders,
+          responseHeaders: sanitizedResHeaders,
+          requestBody,
+          responseBody,
+          duration,
+          timestamp: Date.now(),
+        };
+
+        buffer.push(entry);
+        return response;
+      } catch (error) {
+        const duration = Math.round(performance.now() - startTime);
+
+        const entry: NetworkEntry = {
+          method,
+          url: sanitizedUrl,
+          status: null,
+          requestHeaders: sanitizedReqHeaders,
+          responseHeaders: {},
+          requestBody,
+          responseBody: null,
+          duration,
+          timestamp: Date.now(),
+        };
+
+        buffer.push(entry);
+        throw error;
+      }
+    };
+  }
+
+  function startXHRInterception(): void {
+    originalXHROpen = XMLHttpRequest.prototype.open;
+    originalXHRSend = XMLHttpRequest.prototype.send;
+    originalXHRSetRequestHeader = XMLHttpRequest.prototype.setRequestHeader;
+
+    // Metadata stored on the XHR instance via a WeakMap
+    const xhrMeta = new WeakMap<
+      XMLHttpRequest,
+      {
+        method: string;
+        url: string;
+        headers: Record<string, string>;
+        startTime: number;
+        body: string | null;
+      }
+    >();
+
+    XMLHttpRequest.prototype.open = function (
+      method: string,
+      url: string | URL,
+      ...rest: unknown[]
+    ) {
+      const urlStr = typeof url === 'string' ? url : url.toString();
+      xhrMeta.set(this, {
+        method: method.toUpperCase(),
+        url: urlStr,
+        headers: {},
+        startTime: 0,
+        body: null,
+      });
+      return (originalXHROpen as Function).call(this, method, url, ...rest);
+    };
+
+    XMLHttpRequest.prototype.setRequestHeader = function (
+      name: string,
+      value: string,
+    ) {
+      const meta = xhrMeta.get(this);
+      if (meta) {
+        meta.headers[name] = value;
+      }
+      return originalXHRSetRequestHeader!.call(this, name, value);
+    };
+
+    XMLHttpRequest.prototype.send = function (body?: Document | XMLHttpRequestBodyInit | null) {
+      const meta = xhrMeta.get(this);
+      if (!meta || shouldExclude(meta.url)) {
+        return originalXHRSend!.call(this, body);
+      }
+
+      meta.startTime = performance.now();
+
+      // Capture request body
+      const reqContentType = meta.headers['content-type'] ?? meta.headers['Content-Type'] ?? '';
+      if (isTextContentType(reqContentType) && typeof body === 'string') {
+        if (body.length > maxBodySize) {
+          meta.body = `[truncated, ${body.length} bytes total]`;
+        } else {
+          meta.body = sanitizer.sanitizeString(body);
+        }
+      }
+
+      this.addEventListener('loadend', function () {
+        const duration = Math.round(performance.now() - meta.startTime);
+
+        // Parse response headers
+        const rawHeaders = this.getAllResponseHeaders();
+        const resHeaders: Record<string, string> = {};
+        if (rawHeaders) {
+          for (const line of rawHeaders.trim().split(/[\r\n]+/)) {
+            const idx = line.indexOf(':');
+            if (idx > 0) {
+              const key = line.slice(0, idx).trim();
+              const val = line.slice(idx + 1).trim();
+              resHeaders[key] = val;
+            }
+          }
+        }
+
+        // Response body
+        let responseBody: string | null = null;
+        const resContentType = resHeaders['content-type'] ?? resHeaders['Content-Type'] ?? '';
+        if (isTextContentType(resContentType)) {
+          if (typeof this.response === 'string' || this.responseType === '' || this.responseType === 'text') {
+            const text = this.responseText;
+            if (text.length > maxBodySize) {
+              responseBody = `[truncated, ${text.length} bytes total]`;
+            } else {
+              responseBody = sanitizer.sanitizeString(text);
+            }
+          }
+        } else if (resContentType) {
+          const contentLength = resHeaders['content-length'] ?? resHeaders['Content-Length'];
+          if (contentLength) {
+            responseBody = `[binary, ${contentLength} bytes]`;
+          } else {
+            responseBody = '[binary]';
+          }
+        }
+
+        const entry: NetworkEntry = {
+          method: meta.method,
+          url: sanitizer.sanitizeUrl(meta.url),
+          status: this.status || null,
+          requestHeaders: sanitizer.sanitizeHeaders(meta.headers),
+          responseHeaders: sanitizer.sanitizeHeaders(resHeaders),
+          requestBody: meta.body,
+          responseBody,
+          duration,
+          timestamp: Date.now(),
+        };
+
+        buffer.push(entry);
+      });
+
+      return originalXHRSend!.call(this, body);
+    };
+  }
+
+  function start(): void {
+    if (active) return;
+    active = true;
+    startFetchInterception();
+    startXHRInterception();
+  }
+
+  function stop(): void {
+    if (!active) return;
+    active = false;
+
+    if (originalFetch) {
+      globalThis.fetch = originalFetch;
+      originalFetch = null;
+    }
+
+    if (originalXHROpen) {
+      XMLHttpRequest.prototype.open = originalXHROpen;
+      originalXHROpen = null;
+    }
+
+    if (originalXHRSend) {
+      XMLHttpRequest.prototype.send = originalXHRSend;
+      originalXHRSend = null;
+    }
+
+    if (originalXHRSetRequestHeader) {
+      XMLHttpRequest.prototype.setRequestHeader = originalXHRSetRequestHeader;
+      originalXHRSetRequestHeader = null;
+    }
+  }
+
+  function getEntries(): NetworkEntry[] {
+    return buffer.getAll();
+  }
+
+  function freeze(): NetworkEntry[] {
+    return buffer.freeze();
+  }
+
+  function clear(): void {
+    buffer.clear();
+  }
+
+  return {
+    start,
+    stop,
+    getEntries,
+    freeze,
+    clear,
+    /** @internal — used by the SDK to exclude its own report submission */
+    setExcludedEndpoint,
+  } as NetworkCapture & { setExcludedEndpoint: (endpoint: string) => void };
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -83,8 +83,12 @@ export interface NetworkEntry {
 
 export interface BrowserInfo {
   userAgent: string;
+  browser: string;
+  os: string;
   language: string;
   platform: string;
+  timezone: string;
+  online: boolean;
   screenWidth: number;
   screenHeight: number;
   viewportWidth: number;
@@ -92,6 +96,16 @@ export interface BrowserInfo {
   devicePixelRatio: number;
   url: string;
   referrer: string;
+  memory?: {
+    jsHeapSizeLimit: number;
+    totalJSHeapSize: number;
+    usedJSHeapSize: number;
+  };
+  connection?: {
+    effectiveType: string;
+    downlink: number;
+    rtt: number;
+  };
 }
 
 export interface Breadcrumb {


### PR DESCRIPTION
## Summary

Implements the three core capture modules for the diagnostic SDK (Issue #9):

- **Console capture**: monkey-patches console methods, buffers entries in ring buffer, sanitizes all strings, captures error stack traces
- **Network capture**: wraps fetch and XHR, captures request/response metadata, handles binary/oversized bodies, excludes SDK own requests
- **Browser info**: collects browser/device info with UA parsing, optional memory/connection APIs

## Changes

- `src/capture/console.ts` — `createConsoleCapture()`
- `src/capture/network.ts` — `createNetworkCapture()`
- `src/capture/browser.ts` — `collectBrowserInfo()`
- `src/types.ts` — Extended `BrowserInfo` type
- 44 new tests across 3 test files (80 total)

## Test Plan

- [x] Console capture: 12 tests — all 5 levels, sanitization, buffer limits, stop/restore
- [x] Network capture: 18 tests — fetch/XHR, sanitization, binary bodies, truncation, SDK exclusion
- [x] Browser info: 14 tests — all fields, UA parsing, optional APIs
- [x] TypeScript typecheck passes

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)