### PR TITLE
feat: add prepare script for GitHub install

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "dist"
   ],
   "scripts": {
+    "prepare": "npm run build",
     "build": "tsup",
     "dev": "tsup --watch",
     "test": "vitest run",


### PR DESCRIPTION
Adds `"prepare": "npm run build"` to `package.json` so the SDK builds automatically when installed from GitHub via `npm install github:terna-cc/support-sdk`.

Closes #22

Generated with [Claude Code](https://claude.ai/code)