### PR TITLE
Support chat round 2: send attachment metadata with chat requests (sdk)

### DIFF
--- a/src/chat/__tests__/chat-manager.test.ts
+++ b/src/chat/__tests__/chat-manager.test.ts
@@ -57,10 +57,7 @@ const mockSummary: ReportSummary = {
   tags: [],
 };
 
-function makeManager(
-  maxMessages = 20,
-  attachmentManager?: AttachmentManager,
-) {
+function makeManager(maxMessages = 20, attachmentManager?: AttachmentManager) {
   return createChatManager({
     endpoint: 'https://api.test.com',
     auth: { type: 'none' },

--- a/src/chat/__tests__/chat-transport.test.ts
+++ b/src/chat/__tests__/chat-transport.test.ts
@@ -460,6 +460,74 @@ describe('streamChat', () => {
     expect(onError).toHaveBeenCalledWith('');
   });
 
+  it('includes attachment_meta in request body when provided', async () => {
+    let capturedBody = '';
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((_url: string, init: RequestInit) => {
+        capturedBody = init.body as string;
+        return Promise.resolve(
+          new Response(createReadableStream(['data: {"type":"done"}\n\n']), {
+            status: 200,
+          }),
+        );
+      }),
+    );
+
+    const meta = [
+      { name: 'screenshot.png', type: 'image/png', size: 12345 },
+      { name: 'log.txt', type: 'text/plain', size: 678 },
+    ];
+
+    await streamChat(
+      'https://api.test.com',
+      [],
+      null,
+      new Headers(),
+      vi.fn(),
+      vi.fn(),
+      vi.fn(),
+      new AbortController().signal,
+      undefined,
+      undefined,
+      meta,
+    );
+
+    const body = JSON.parse(capturedBody);
+    expect(body.attachment_meta).toEqual(meta);
+  });
+
+  it('omits attachment_meta from request body when not provided', async () => {
+    let capturedBody = '';
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((_url: string, init: RequestInit) => {
+        capturedBody = init.body as string;
+        return Promise.resolve(
+          new Response(createReadableStream(['data: {"type":"done"}\n\n']), {
+            status: 200,
+          }),
+        );
+      }),
+    );
+
+    await streamChat(
+      'https://api.test.com',
+      [],
+      null,
+      new Headers(),
+      vi.fn(),
+      vi.fn(),
+      vi.fn(),
+      new AbortController().signal,
+    );
+
+    const body = JSON.parse(capturedBody);
+    expect(body.attachment_meta).toBeUndefined();
+  });
+
   it('omits locale from request body when not provided', async () => {
     let capturedBody = '';
 

--- a/src/chat/chat-transport.ts
+++ b/src/chat/chat-transport.ts
@@ -1,4 +1,9 @@
-import type { ChatMessage, DiagnosticSnapshot, ReportSummary } from '../types';
+import type {
+  AttachmentMetadata,
+  ChatMessage,
+  DiagnosticSnapshot,
+  ReportSummary,
+} from '../types';
 
 export async function streamChat(
   endpoint: string,
@@ -11,6 +16,7 @@ export async function streamChat(
   signal: AbortSignal,
   locale?: string,
   onError?: (message: string) => void,
+  attachmentMeta?: AttachmentMetadata[],
 ): Promise<void> {
   const url = `${endpoint.replace(/\/+$/, '')}/chat`;
 
@@ -24,6 +30,7 @@ export async function streamChat(
     body: JSON.stringify({
       messages,
       diagnostic_context: diagnosticContext,
+      ...(attachmentMeta ? { attachment_meta: attachmentMeta } : {}),
       ...(locale ? { locale } : {}),
     }),
     signal,

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -249,6 +249,7 @@ export class SupportSDK {
         auth,
         maxMessages: chatConfig.maxMessages ?? 20,
         locale: this.locale,
+        attachmentManager: this.attachmentMgr ?? undefined,
       });
       this.modal.setChatManager(this.chatMgr);
 


### PR DESCRIPTION
## Summary
Automated implementation from issue #54.
Specs: SPEC-126

Closes #54

## Test plan
- [ ] CI passes
- [ ] Manual verification

Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add support for sending attachment metadata with chat requests from the SDK through the chat manager and transport.

New Features:
- Allow the chat manager to accept an attachment manager and derive attachment metadata for outgoing chat requests.
- Include optional attachment_meta in chat transport request bodies when attachment metadata is provided.
- Wire the SDK’s support flow to pass its attachment manager into the chat manager so attachments can be reflected in requests.

Tests:
- Add chat manager tests to verify attachment metadata is forwarded when attachments exist and omitted otherwise.
- Add chat transport tests to verify attachment_meta is serialized into or omitted from the request body as appropriate.