### PR TITLE
"Show confirmation after report submission + reset diagnostic buffers" (support-sdk)

### DIFF
--- a/src/capture/performance.test.ts
+++ b/src/capture/performance.test.ts
@@ -307,6 +307,46 @@ describe('createPerformanceCapture', () => {
     });
   });
 
+  describe('clear()', () => {
+    it('resets long task buffer', () => {
+      vi.spyOn(Date, 'now').mockReturnValue(1000);
+
+      const capture = createPerformanceCapture();
+
+      triggerObserver('longtask', [
+        { duration: 80, startTime: 500 },
+        { duration: 120, startTime: 600 },
+      ]);
+
+      expect(capture.getMetrics().longTasks).toHaveLength(2);
+
+      capture.clear();
+
+      expect(capture.getMetrics().longTasks).toHaveLength(0);
+
+      vi.restoreAllMocks();
+      capture.destroy();
+    });
+
+    it('allows new long tasks to be captured after clear', () => {
+      vi.spyOn(Date, 'now').mockReturnValue(2000);
+
+      const capture = createPerformanceCapture();
+
+      triggerObserver('longtask', [{ duration: 80, startTime: 500 }]);
+      expect(capture.getMetrics().longTasks).toHaveLength(1);
+
+      capture.clear();
+
+      triggerObserver('longtask', [{ duration: 100, startTime: 700 }]);
+      expect(capture.getMetrics().longTasks).toHaveLength(1);
+      expect(capture.getMetrics().longTasks[0].duration).toBe(100);
+
+      vi.restoreAllMocks();
+      capture.destroy();
+    });
+  });
+
   describe('destroy()', () => {
     it('disconnects all observers', () => {
       const capture = createPerformanceCapture();

--- a/src/capture/performance.ts
+++ b/src/capture/performance.ts
@@ -10,6 +10,7 @@ import type {
 
 export interface PerformanceCapture {
   getMetrics(): PerformanceMetrics;
+  clear(): void;
   destroy(): void;
 }
 
@@ -154,6 +155,10 @@ export function createPerformanceCapture(
     };
   }
 
+  function clear(): void {
+    longTaskBuffer.clear();
+  }
+
   function destroy(): void {
     for (const observer of observers) {
       observer.disconnect();
@@ -161,5 +166,5 @@ export function createPerformanceCapture(
     observers.length = 0;
   }
 
-  return { getMetrics, destroy };
+  return { getMetrics, clear, destroy };
 }

--- a/src/capture/rage-click.test.ts
+++ b/src/capture/rage-click.test.ts
@@ -277,6 +277,53 @@ describe('createRageClickCapture', () => {
     });
   });
 
+  describe('clear', () => {
+    it('resets all detected rage clicks', () => {
+      capture = createRageClickCapture();
+
+      const btn = document.createElement('button');
+      btn.textContent = 'Submit';
+      document.body.appendChild(btn);
+
+      clickAt(100, 100, btn);
+      clickAt(101, 101, btn);
+      clickAt(102, 102, btn);
+
+      expect(capture.getDetected()).toHaveLength(1);
+
+      capture.clear();
+
+      expect(capture.getDetected()).toHaveLength(0);
+
+      document.body.removeChild(btn);
+    });
+
+    it('allows new detections after clear', () => {
+      capture = createRageClickCapture();
+
+      const btn = document.createElement('button');
+      btn.textContent = 'Submit';
+      document.body.appendChild(btn);
+
+      clickAt(100, 100, btn);
+      clickAt(101, 101, btn);
+      clickAt(102, 102, btn);
+
+      expect(capture.getDetected()).toHaveLength(1);
+
+      capture.clear();
+
+      // New rage clicks should be detected
+      clickAt(200, 200, btn);
+      clickAt(201, 201, btn);
+      clickAt(202, 202, btn);
+
+      expect(capture.getDetected()).toHaveLength(1);
+
+      document.body.removeChild(btn);
+    });
+  });
+
   describe('RageClick entry fields', () => {
     it('includes all required fields', () => {
       capture = createRageClickCapture();

--- a/src/capture/rage-click.ts
+++ b/src/capture/rage-click.ts
@@ -13,6 +13,7 @@ export interface RageClick {
 
 export interface RageClickCapture {
   getDetected(): RageClick[];
+  clear(): void;
   destroy(): void;
 }
 
@@ -125,11 +126,17 @@ export function createRageClickCapture(config?: {
     return buffer.getAll();
   }
 
+  function clear(): void {
+    buffer.clear();
+    recentClicks.length = 0;
+    lastRageClickTime.clear();
+  }
+
   function destroy(): void {
     document.removeEventListener('click', handleClick, true);
     recentClicks.length = 0;
     lastRageClickTime.clear();
   }
 
-  return { getDetected, destroy };
+  return { getDetected, clear, destroy };
 }

--- a/src/i18n/translations.test.ts
+++ b/src/i18n/translations.test.ts
@@ -19,6 +19,10 @@ describe('translations', () => {
       'There was a problem processing your message. Please try again.',
     );
     expect(translations['en'].retryButton).toBe('Try again');
+    expect(translations['en'].reportSubmitted).toBe(
+      'Your report has been submitted. Our team will review it shortly. Thank you!',
+    );
+    expect(translations['en'].reportClose).toBe('Close');
   });
 
   it('has Spanish translations', () => {
@@ -40,6 +44,10 @@ describe('translations', () => {
       'Hubo un problema al procesar tu mensaje. Por favor intenta de nuevo.',
     );
     expect(translations['es'].retryButton).toBe('Intentar de nuevo');
+    expect(translations['es'].reportSubmitted).toBe(
+      'Tu reporte fue enviado. Nuestro equipo lo revisará pronto. ¡Gracias!',
+    );
+    expect(translations['es'].reportClose).toBe('Cerrar');
   });
 });
 
@@ -94,6 +102,8 @@ describe('getTranslations', () => {
     expect(t).toHaveProperty('submitFailed');
     expect(t).toHaveProperty('errorMessage');
     expect(t).toHaveProperty('retryButton');
+    expect(t).toHaveProperty('reportSubmitted');
+    expect(t).toHaveProperty('reportClose');
   });
 
   it('returns all expected keys for Spanish', () => {
@@ -116,5 +126,7 @@ describe('getTranslations', () => {
     expect(t).toHaveProperty('submitFailed');
     expect(t).toHaveProperty('errorMessage');
     expect(t).toHaveProperty('retryButton');
+    expect(t).toHaveProperty('reportSubmitted');
+    expect(t).toHaveProperty('reportClose');
   });
 });

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -17,6 +17,8 @@ export interface Translations {
   submitFailed: string;
   errorMessage: string;
   retryButton: string;
+  reportSubmitted: string;
+  reportClose: string;
 }
 
 export const translations: Record<string, Translations> = {
@@ -40,6 +42,9 @@ export const translations: Record<string, Translations> = {
     errorMessage:
       'There was a problem processing your message. Please try again.',
     retryButton: 'Try again',
+    reportSubmitted:
+      'Your report has been submitted. Our team will review it shortly. Thank you!',
+    reportClose: 'Close',
   },
   es: {
     triggerLabel: 'Ayuda',
@@ -61,6 +66,9 @@ export const translations: Record<string, Translations> = {
     errorMessage:
       'Hubo un problema al procesar tu mensaje. Por favor intenta de nuevo.',
     retryButton: 'Intentar de nuevo',
+    reportSubmitted:
+      'Tu reporte fue enviado. Nuestro equipo lo revisará pronto. ¡Gracias!',
+    reportClose: 'Cerrar',
   },
 };
 

--- a/src/sdk.test.ts
+++ b/src/sdk.test.ts
@@ -599,6 +599,83 @@ describe('SupportSDK', () => {
     });
   });
 
+  describe('resetBuffers()', () => {
+    it('clears all diagnostic buffers without stopping capture', () => {
+      const sdk = SupportSDK.init(minimalConfig());
+
+      // Generate some data in the buffers
+      console.log('test log 1');
+      console.log('test log 2');
+
+      sdk.addBreadcrumb({ type: 'custom', message: 'test breadcrumb' });
+
+      // resetBuffers should not throw
+      sdk.resetBuffers();
+
+      // Console should still be patched (capture is still active)
+      const originalLog = console.log;
+      expect(typeof originalLog).toBe('function');
+
+      sdk.destroy();
+    });
+
+    it('ensures second report after reset has clean data', async () => {
+      const fetchSpy = vi
+        .spyOn(globalThis, 'fetch')
+        .mockImplementation(() =>
+          Promise.resolve(
+            new Response(JSON.stringify({ id: 'report-1' }), { status: 200 }),
+          ),
+        );
+
+      const sdk = SupportSDK.init(
+        minimalConfig({
+          capture: { network: false },
+          chat: { enabled: false },
+        }),
+      );
+
+      // Add breadcrumbs before first report
+      sdk.addBreadcrumb({ type: 'custom', message: 'first session breadcrumb' });
+
+      sdk.captureOnOpen();
+      await new Promise((r) => setTimeout(r, 50));
+
+      // First submit
+      await sdk.submitWithIntent('bug', 'First report');
+
+      // Reset buffers (simulating what happens after successful submission)
+      sdk.resetBuffers();
+
+      // Second captureOnOpen after reset
+      sdk.captureOnOpen();
+      await new Promise((r) => setTimeout(r, 50));
+
+      // Second submit
+      await sdk.submitWithIntent('bug', 'Second report');
+
+      // Find the two report calls
+      const reportCalls = fetchSpy.mock.calls.filter(
+        (call) =>
+          typeof call[0] === 'string' &&
+          (call[0] as string).includes('/reports'),
+      );
+      expect(reportCalls.length).toBeGreaterThanOrEqual(2);
+
+      // The second report's breadcrumbs should be empty (buffers were reset)
+      const secondCall = reportCalls[reportCalls.length - 1];
+      const formData = secondCall[1]?.body as FormData;
+      const reportJson = formData?.get('report') as string;
+      if (reportJson) {
+        const report = JSON.parse(reportJson);
+        expect(report.breadcrumbs).toEqual([]);
+      }
+
+      fetchSpy.mockRestore();
+      sdk.destroy();
+    });
+  });
+
   describe('SDK_VERSION export', () => {
     it('is exported from the main entry', async () => {
       const { SDK_VERSION } = await import('./index');

--- a/src/sdk.test.ts
+++ b/src/sdk.test.ts
@@ -636,7 +636,10 @@ describe('SupportSDK', () => {
       );
 
       // Add breadcrumbs before first report
-      sdk.addBreadcrumb({ type: 'custom', message: 'first session breadcrumb' });
+      sdk.addBreadcrumb({
+        type: 'custom',
+        message: 'first session breadcrumb',
+      });
 
       sdk.captureOnOpen();
       await new Promise((r) => setTimeout(r, 50));

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -216,6 +216,9 @@ export class SupportSDK {
           if (!result.success) {
             throw new Error(result.error?.message ?? 'Failed to send report');
           }
+
+          // Reset diagnostic buffers so the next report starts clean
+          this.resetBuffers();
         },
         onCancel: () => {
           this.frozenErrorInfo = null;
@@ -546,6 +549,23 @@ export class SupportSDK {
    * Clear pending diagnostics without submitting (prevent memory leaks).
    */
   clearPendingDiagnostics(): void {
+    this._pendingDiagnostics = null;
+  }
+
+  /**
+   * Reset all diagnostic event buffers after a successful report submission.
+   * Clears accumulated console logs, network logs, breadcrumbs, rage clicks,
+   * and long tasks so the next report starts with a clean slate.
+   *
+   * Does NOT clear: browser info (static), SDK config, or user context.
+   */
+  resetBuffers(): void {
+    this.consoleCapture?.clear();
+    this.networkCapture?.clear();
+    this.breadcrumbCapture?.clear();
+    this.rageClickCapture?.clear();
+    this.performanceCapture?.clear();
+    this.frozenErrorInfo = null;
     this._pendingDiagnostics = null;
   }
 

--- a/src/ui/modal.test.ts
+++ b/src/ui/modal.test.ts
@@ -581,7 +581,7 @@ describe('createReviewModal', () => {
     });
   });
 
-  it('shows success message after successful submission', async () => {
+  it('shows confirmation view after successful submission', async () => {
     const modal = createReviewModal(config, getTranslations('en'), callbacks);
     modal.open({ consoleLogs: makeConsoleLogs(1) });
 
@@ -591,10 +591,20 @@ describe('createReviewModal', () => {
     sendBtn.click();
 
     await vi.waitFor(() => {
-      const statusMsg = getShadow()!.querySelector('.status-message.success');
-      expect(statusMsg).not.toBeNull();
-      expect(statusMsg!.textContent).toBe('Report sent!');
+      const confirmationView =
+        getShadow()!.querySelector('.confirmation-view');
+      expect(confirmationView).not.toBeNull();
     });
+
+    const message = getShadow()!.querySelector('.confirmation-message');
+    expect(message).not.toBeNull();
+    expect(message!.textContent).toBe(
+      'Your report has been submitted. Our team will review it shortly. Thank you!',
+    );
+
+    const closeBtn = getShadow()!.querySelector('.confirmation-close-btn');
+    expect(closeBtn).not.toBeNull();
+    expect(closeBtn!.textContent).toBe('Close');
   });
 
   it('sets role=dialog on backdrop container', () => {
@@ -708,6 +718,140 @@ describe('createReviewModal', () => {
 
       modal.close();
     }
+  });
+
+  describe('confirmation view', () => {
+    it('auto-closes after 4 seconds', async () => {
+      vi.useFakeTimers();
+      const onCloseSpy = vi.fn();
+      const modal = createReviewModal(config, getTranslations('en'), {
+        ...callbacks,
+        onClose: onCloseSpy,
+      });
+      modal.open({ consoleLogs: makeConsoleLogs(1) });
+
+      const sendBtn = getShadow()!.querySelector(
+        '.btn-primary',
+      ) as HTMLButtonElement;
+      sendBtn.click();
+
+      // Flush microtask queue to let the async onSubmit resolve
+      // and showConfirmation to be called
+      await vi.advanceTimersByTimeAsync(0);
+
+      // Confirmation view should now be showing
+      expect(getShadow()!.querySelector('.confirmation-view')).not.toBeNull();
+
+      // Advance to trigger auto-close
+      vi.advanceTimersByTime(4000);
+
+      // Modal should be closed
+      expect(getHost()).toBeNull();
+      expect(onCloseSpy).toHaveBeenCalled();
+
+      vi.useRealTimers();
+    });
+
+    it('manual close button dismisses immediately and clears auto-close timer', async () => {
+      vi.useFakeTimers();
+      const onCloseSpy = vi.fn();
+      const modal = createReviewModal(config, getTranslations('en'), {
+        ...callbacks,
+        onClose: onCloseSpy,
+      });
+      modal.open({ consoleLogs: makeConsoleLogs(1) });
+
+      const sendBtn = getShadow()!.querySelector(
+        '.btn-primary',
+      ) as HTMLButtonElement;
+      sendBtn.click();
+
+      // Flush microtask queue to let the async onSubmit resolve
+      await vi.advanceTimersByTimeAsync(0);
+
+      // Click the close button on confirmation view
+      const closeBtn = getShadow()!.querySelector(
+        '.confirmation-close-btn',
+      ) as HTMLButtonElement;
+      expect(closeBtn).not.toBeNull();
+      closeBtn.click();
+
+      // Modal should be closed immediately
+      expect(getHost()).toBeNull();
+      expect(onCloseSpy).toHaveBeenCalledTimes(1);
+
+      // Advancing timer should not cause issues (no double-close)
+      vi.advanceTimersByTime(5000);
+      expect(onCloseSpy).toHaveBeenCalledTimes(1);
+
+      vi.useRealTimers();
+    });
+
+    it('shows Spanish confirmation message when locale is es', async () => {
+      const modal = createReviewModal(
+        config,
+        getTranslations('es'),
+        callbacks,
+      );
+      modal.open({ consoleLogs: makeConsoleLogs(1) });
+
+      const sendBtn = getShadow()!.querySelector(
+        '.btn-primary',
+      ) as HTMLButtonElement;
+      sendBtn.click();
+
+      await vi.waitFor(() => {
+        const confirmationView =
+          getShadow()!.querySelector('.confirmation-view');
+        expect(confirmationView).not.toBeNull();
+      });
+
+      const message = getShadow()!.querySelector('.confirmation-message');
+      expect(message!.textContent).toBe(
+        'Tu reporte fue enviado. Nuestro equipo lo revisará pronto. ¡Gracias!',
+      );
+
+      const closeBtn = getShadow()!.querySelector('.confirmation-close-btn');
+      expect(closeBtn!.textContent).toBe('Cerrar');
+    });
+
+    it('replaces modal content with confirmation (not overlay)', async () => {
+      const modal = createReviewModal(config, getTranslations('en'), callbacks);
+      modal.open({ consoleLogs: makeConsoleLogs(1) });
+
+      const sendBtn = getShadow()!.querySelector(
+        '.btn-primary',
+      ) as HTMLButtonElement;
+      sendBtn.click();
+
+      await vi.waitFor(() => {
+        const confirmationView =
+          getShadow()!.querySelector('.confirmation-view');
+        expect(confirmationView).not.toBeNull();
+      });
+
+      // Original form elements should no longer be in the DOM
+      expect(getShadow()!.querySelector('.description-textarea')).toBeNull();
+      expect(getShadow()!.querySelector('.category-list')).toBeNull();
+      expect(getShadow()!.querySelector('.modal-footer')).toBeNull();
+    });
+
+    it('includes a checkmark icon', async () => {
+      const modal = createReviewModal(config, getTranslations('en'), callbacks);
+      modal.open({ consoleLogs: makeConsoleLogs(1) });
+
+      const sendBtn = getShadow()!.querySelector(
+        '.btn-primary',
+      ) as HTMLButtonElement;
+      sendBtn.click();
+
+      await vi.waitFor(() => {
+        const iconEl = getShadow()!.querySelector('.confirmation-icon');
+        expect(iconEl).not.toBeNull();
+        const svg = iconEl!.querySelector('svg');
+        expect(svg).not.toBeNull();
+      });
+    });
   });
 
   describe('chat mode diagnostic context', () => {

--- a/src/ui/modal.test.ts
+++ b/src/ui/modal.test.ts
@@ -591,8 +591,7 @@ describe('createReviewModal', () => {
     sendBtn.click();
 
     await vi.waitFor(() => {
-      const confirmationView =
-        getShadow()!.querySelector('.confirmation-view');
+      const confirmationView = getShadow()!.querySelector('.confirmation-view');
       expect(confirmationView).not.toBeNull();
     });
 
@@ -788,11 +787,7 @@ describe('createReviewModal', () => {
     });
 
     it('shows Spanish confirmation message when locale is es', async () => {
-      const modal = createReviewModal(
-        config,
-        getTranslations('es'),
-        callbacks,
-      );
+      const modal = createReviewModal(config, getTranslations('es'), callbacks);
       modal.open({ consoleLogs: makeConsoleLogs(1) });
 
       const sendBtn = getShadow()!.querySelector(

--- a/src/ui/modal.ts
+++ b/src/ui/modal.ts
@@ -564,10 +564,6 @@ export function createReviewModal(
     closeBtn.type = 'button';
     closeBtn.textContent = translations.reportClose;
     closeBtn.addEventListener('click', () => {
-      if (autoCloseTimer) {
-        clearTimeout(autoCloseTimer);
-        autoCloseTimer = null;
-      }
       close();
     });
     confirmationView.appendChild(closeBtn);

--- a/src/ui/styles.ts
+++ b/src/ui/styles.ts
@@ -527,6 +527,74 @@ export const modalStyles = `
     border: 1px solid #bbf7d0;
   }
 
+  /* ── Confirmation view (post-submission) ── */
+
+  .confirmation-view {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 40px 24px 32px;
+    text-align: center;
+    gap: 16px;
+    flex: 1;
+  }
+
+  .confirmation-icon {
+    width: 56px;
+    height: 56px;
+    border-radius: 50%;
+    background: #f0fdf4;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    animation: confirmation-pop 0.3s ease-out;
+  }
+
+  .confirmation-icon svg {
+    width: 28px;
+    height: 28px;
+    color: var(--support-success);
+  }
+
+  @keyframes confirmation-pop {
+    0% { transform: scale(0.5); opacity: 0; }
+    70% { transform: scale(1.1); }
+    100% { transform: scale(1); opacity: 1; }
+  }
+
+  .confirmation-message {
+    font-size: 15px;
+    line-height: 1.6;
+    color: var(--support-text);
+    max-width: 280px;
+  }
+
+  .confirmation-close-btn {
+    appearance: none;
+    border: none;
+    cursor: pointer;
+    font-family: var(--support-font);
+    font-size: 14px;
+    font-weight: 500;
+    padding: 8px 24px;
+    border-radius: var(--support-radius);
+    background: var(--support-bg-secondary);
+    color: var(--support-text);
+    border: 1px solid var(--support-border);
+    transition: background 0.1s;
+    margin-top: 8px;
+  }
+
+  .confirmation-close-btn:hover {
+    background: var(--support-border);
+  }
+
+  .confirmation-close-btn:focus-visible {
+    outline: 2px solid var(--support-primary-color);
+    outline-offset: 2px;
+  }
+
   @media (max-width: 480px) {
     .modal-content {
       left: 8px;


### PR DESCRIPTION
## Summary
Automated implementation from issue #56.
Specs: SPEC-153

Closes #56

## Test plan
- [ ] CI passes
- [ ] Manual verification

Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Show a localized post-submission confirmation view in the support modal and reset diagnostic buffers after each successful report so subsequent reports start with fresh data.

New Features:
- Display a dedicated confirmation view with icon, message, and close button after successful report submission instead of an inline status message.
- Expose a resetBuffers() method on SupportSDK to clear diagnostic event buffers between reports.

Enhancements:
- Add auto-close behavior and manual close handling for the confirmation view, including focus management and styling.
- Extend rage-click and performance capture modules with clear() APIs to reset their internal buffers, and wire them into SDK buffer resets.
- Add new i18n strings and tests for localized confirmation messaging in English and Spanish.

Tests:
- Add UI tests covering confirmation view behavior, timing, localization, DOM replacement, and icon presence.
- Add SDK tests verifying resetBuffers() clears diagnostics while keeping capture active and ensuring clean data for subsequent reports.
- Add capture tests ensuring rage-click and performance clear() methods reset state and allow new events.